### PR TITLE
Download CSV, UPLOAD CSV and DEDUP UploadedTransactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+http://homelight-phx.herokuapp.com/
+
 # Uploaded Transactions Manager
 
 This tool allows real estate agents to upload and manager their past real estate transactions.

--- a/app/controllers/agents_controller.rb
+++ b/app/controllers/agents_controller.rb
@@ -2,9 +2,17 @@ class AgentsController < ApplicationController
   def show
     @agent = Agent.find(params[:id])
     @uploaded_transactions = @agent.all_transactions
+    respond_to do |format|
+      format.html
+      format.csv { send_data @uploaded_transactions.to_csv, filename: "TRANSACTIONS-#{Date.today}.csv" }
+    end
   end
 
   def random_agent
     redirect_to agent_path(Agent.all.sample)
   end
+  
 end
+
+# @uploaded_transactions = @agent.all_transactions
+# UploadedTransaction.attribute_names

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,3 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
-  http_basic_authenticate_with :name => ENV["AUTH-NAME"], :password => ENV["AUTH-PASSWORD"]
 end

--- a/app/controllers/uploaded_transactions_controller.rb
+++ b/app/controllers/uploaded_transactions_controller.rb
@@ -3,7 +3,7 @@ class UploadedTransactionsController < ApplicationController
     @agent = Agent.find(params[:agent_id])
     @uploaded_transaction = @agent.uploaded_seller_transactions.new
   end
-
+  
   def create
     agent = Agent.find(params[:agent_id])
     uploaded_transaction = agent.uploaded_seller_transactions.create(uploaded_transaction_params)
@@ -14,10 +14,16 @@ class UploadedTransactionsController < ApplicationController
       render "new"
     end
   end
-
+  
+  def import
+    UploadedTransaction.import(params[:file])
+    redirect_to root_path, notice: "Transactions uploaded succesfully!"
+  end
+  
   private
 
   def uploaded_transaction_params
     params.require(:uploaded_transaction).permit(:address, :city, :state, :zip, :listing_agent, :listing_price, :listing_date, :selling_price, :selling_agent, :selling_date, :status, :property_type)
   end
+
 end

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -3,7 +3,7 @@ class Agent < ApplicationRecord
   has_many :uploaded_buyer_transactions, class_name: "UploadedTransaction", foreign_key: :selling_agent_id
 
   def all_transactions
-    UploadedTransaction.where("listing_agent_id = ? OR selling_agent_id = ?", id, id)
+    UploadedTransaction.where("listing_agent_id = ? OR selling_agent_id = ?", id, id) #
   end
 
   def recent_transactions

--- a/app/models/uploaded_transaction.rb
+++ b/app/models/uploaded_transaction.rb
@@ -8,4 +8,29 @@ class UploadedTransaction < ApplicationRecord
   def full_address
     "#{address}, #{city}, #{state} #{zip}"
   end
+  
+  def self.dedup
+    columns = [:zip, :address, :selling_date]
+    ids = UploadedTransaction.order('created_at ASC').select("#{columns.join(',')}, COUNT(*)").group(columns).having("COUNT(*) > 1").pluck(:id)
+    UploadedTransaction.where(id: ids).destroy_all
+  end
+  
+  def self.import(file)
+    CSV.foreach(file.path, headers: true) do |row|
+      puts row
+      UploadedTransaction.create! row.to_hash
+    end
+    UploadedTransaction.dedup
+  end
+  
+  def self.to_csv
+    attributes = UploadedTransaction.attribute_names - ["created_at", "updated_at", "id"]
+    CSV.generate(headers: true) do |csv|
+      csv << attributes
+      all.each do |user|
+        csv << attributes.map{ |attr| user.send(attr) }
+      end
+    end
+  end
+  
 end

--- a/app/views/agents/show.html.slim
+++ b/app/views/agents/show.html.slim
@@ -1,12 +1,22 @@
 h1 = @agent.full_name
 p = @agent.bio
 
-= link_to "Add Transaction", new_agent_uploaded_transaction_path(@agent), class: "btn btn-primary"
 
-h3 Recent Transactions
+div 
+  = form_tag import_agent_uploaded_transactions_path(@agent), multipart: true do
+    = file_field_tag :file
+    = submit_tag "Bulk Upload Transactions", class: "btn btn-primary"
+= link_to "Add Single Transaction", new_agent_uploaded_transaction_path(@agent), class: "btn btn-primary"
+
+
+h3 Recent Transactions 
+= link_to "Download Transactions ", agent_path(@agent, :format => "csv")
+
+
 table
   thead
     tr
+      th Age
       th Address
       th Listed
       th Listing Price
@@ -16,6 +26,7 @@ table
   tbody
     - @uploaded_transactions.each do |uploaded_transaction|
       tr
+        td = time_ago_in_words(uploaded_transaction.created_at, include_seconds: true)
         td = uploaded_transaction.full_address
         td = uploaded_transaction.listing_date
         td = uploaded_transaction.listing_price

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,7 @@
 require_relative 'boot'
 
 require 'rails/all'
+require 'csv'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,8 @@ Rails.application.routes.draw do
   root to: "agents#random_agent"
 
   resources :agents do
-    resources :uploaded_transactions
+    resources :uploaded_transactions do
+      collection {post :import}
+    end
   end
 end


### PR DESCRIPTION
1. Build a bulk transaction uploader - allow agents to upload a CSV where each row represents a new transaction
- Each column should represent the columns in the model
- De-dupe on address, zip and selling_date